### PR TITLE
fix(chart): fix invalid rbac specs for auto cluster roles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ kustomize: ## Download kustomize locally if necessary.
 ENVTEST = $(GOBIN)/setup-envtest
 .PHONY: envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17)
 
 # go-install-tool will 'go install' any package $2 and install it to $1
 define go-install-tool

--- a/chart/cloud-autoscale-controller/templates/clusterrole-edit.yaml
+++ b/chart/cloud-autoscale-controller/templates/clusterrole-edit.yaml
@@ -16,9 +16,8 @@ rules:
 - apiGroups:
   - "cloudautoscale.infra.doodle.com"
   resources:
-  - cloudautoscalerealms
-  - cloudautoscaleclients
-  - cloudautoscaleusers
+  - awsrdsinstances
+  - mongodbatlasclusters
   verbs:
   - create
   - delete
@@ -30,9 +29,8 @@ rules:
 - apiGroups:
   - "cloudautoscale.infra.doodle.com"
   resources:
-  - cloudautoscalerealms/status
-  - cloudautoscaleclients/status
-  - cloudautoscaleusers/status
+  - awsrdsinstances/status
+  - mongodbatlasclusters/status
   verbs:
   - get
 {{- end }}

--- a/chart/cloud-autoscale-controller/templates/clusterrole-view.yaml
+++ b/chart/cloud-autoscale-controller/templates/clusterrole-view.yaml
@@ -15,9 +15,8 @@ rules:
 - apiGroups:
   - "cloudautoscale.infra.doodle.com"
   resources:
-  - cloudautoscalerealms
-  - cloudautoscaleclients
-  - cloudautoscaleusers
+  - awsrdsinstances
+  - mongodbatlasclusters
   verbs:
   - get
   - list
@@ -25,9 +24,8 @@ rules:
 - apiGroups:
   - "cloudautoscale.infra.doodle.com"
   resources:
-  - cloudautoscalerealms/status
-  - cloudautoscaleclients/status
-  - cloudautoscaleusers/status
+  - awsrdsinstances/status
+  - mongodbatlasclusters/status
   verbs:
   - get
 {{- end }}


### PR DESCRIPTION
## Current situation
Currently the cluster roles are useless. They target the wrong resources (copy n paste error from  a template repo).

## Proposal
Update proper resource names.
