### PR TITLE
fix(chart): rbac for neo4jinstances

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -76,10 +76,10 @@ jobs:
     strategy:
       matrix:
         kubernetes-version:
-        - "1.27"
-        - "1.28"
-        - "1.29"
-        - "1.30"
+        - "1.31"
+        - "1.32"
+        - "1.33"
+        - "1.34"
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/base/crd/bases
+	cp config/base/crd/bases/* chart/apollo-controller/crds/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -121,8 +122,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 CONTROLLER_GEN = $(GOBIN)/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.1)
-	cp config/base/crd/bases/* chart/cloud-autoscale-controller/crds/
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.20.0)
 
 GOLANGCI_LINT = $(GOBIN)/golangci-lint
 .PHONY: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/base/crd/bases
-	cp config/base/crd/bases/* chart/apollo-controller/crds/
+	cp config/base/crd/bases/* chart/cloud-autoscale-controller/crds/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/chart/cloud-autoscale-controller/crds/cloudautoscale.infra.doodle.com_awsrdsinstances.yaml
+++ b/chart/cloud-autoscale-controller/crds/cloudautoscale.infra.doodle.com_awsrdsinstances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: awsrdsinstances.cloudautoscale.infra.doodle.com
 spec:
   group: cloudautoscale.infra.doodle.com

--- a/chart/cloud-autoscale-controller/crds/cloudautoscale.infra.doodle.com_mongodbatlasclusters.yaml
+++ b/chart/cloud-autoscale-controller/crds/cloudautoscale.infra.doodle.com_mongodbatlasclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: mongodbatlasclusters.cloudautoscale.infra.doodle.com
 spec:
   group: cloudautoscale.infra.doodle.com

--- a/chart/cloud-autoscale-controller/crds/cloudautoscale.infra.doodle.com_neo4jaurainstances.yaml
+++ b/chart/cloud-autoscale-controller/crds/cloudautoscale.infra.doodle.com_neo4jaurainstances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: neo4jaurainstances.cloudautoscale.infra.doodle.com
 spec:
   group: cloudautoscale.infra.doodle.com

--- a/chart/cloud-autoscale-controller/templates/clusterrole-edit.yaml
+++ b/chart/cloud-autoscale-controller/templates/clusterrole-edit.yaml
@@ -18,6 +18,7 @@ rules:
   resources:
   - awsrdsinstances
   - mongodbatlasclusters
+  - neo4jaurainstances
   verbs:
   - create
   - delete
@@ -31,6 +32,7 @@ rules:
   resources:
   - awsrdsinstances/status
   - mongodbatlasclusters/status
+  - neo4jaurainstances/status
   verbs:
   - get
 {{- end }}

--- a/chart/cloud-autoscale-controller/templates/clusterrole-view.yaml
+++ b/chart/cloud-autoscale-controller/templates/clusterrole-view.yaml
@@ -17,6 +17,7 @@ rules:
   resources:
   - awsrdsinstances
   - mongodbatlasclusters
+  - neo4jaurainstances
   verbs:
   - get
   - list
@@ -26,6 +27,7 @@ rules:
   resources:
   - awsrdsinstances/status
   - mongodbatlasclusters/status
+  - neo4jaurainstances/status
   verbs:
   - get
 {{- end }}

--- a/chart/cloud-autoscale-controller/templates/clusterrole.yaml
+++ b/chart/cloud-autoscale-controller/templates/clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
   resources:
   - awsrdsinstances
   - mongodbatlasclusters
+  - neo4jaurainstances
   verbs:
   - create
   - delete
@@ -29,6 +30,7 @@ rules:
   resources:
   - awsrdsinstances/status
   - mongodbatlasclusters/status
+  - neo4jaurainstances/status
   verbs:
   - get
   - patch

--- a/config/base/crd/bases/cloudautoscale.infra.doodle.com_awsrdsinstances.yaml
+++ b/config/base/crd/bases/cloudautoscale.infra.doodle.com_awsrdsinstances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: awsrdsinstances.cloudautoscale.infra.doodle.com
 spec:
   group: cloudautoscale.infra.doodle.com

--- a/config/base/crd/bases/cloudautoscale.infra.doodle.com_mongodbatlasclusters.yaml
+++ b/config/base/crd/bases/cloudautoscale.infra.doodle.com_mongodbatlasclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: mongodbatlasclusters.cloudautoscale.infra.doodle.com
 spec:
   group: cloudautoscale.infra.doodle.com

--- a/config/base/crd/bases/cloudautoscale.infra.doodle.com_neo4jaurainstances.yaml
+++ b/config/base/crd/bases/cloudautoscale.infra.doodle.com_neo4jaurainstances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: neo4jaurainstances.cloudautoscale.infra.doodle.com
 spec:
   group: cloudautoscale.infra.doodle.com

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,15 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - cloudautoscale.infra.doodle.com
   resources:
   - awsrdsinstances
@@ -36,12 +45,3 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch

--- a/internal/controllers/mongodbatlascluster_controller.go
+++ b/internal/controllers/mongodbatlascluster_controller.go
@@ -166,7 +166,6 @@ func (r *MongoDBAtlasClusterReconciler) Reconcile(ctx context.Context, req ctrl.
 		logger.Error(err, "reconcile error occurred")
 		cluster = infrav1beta1.MongoDBAtlasClusterReady(cluster, metav1.ConditionFalse, "ReconciliationFailed", err.Error())
 		r.Recorder.Event(&cluster, "Normal", "error", err.Error())
-		result.Requeue = true
 	}
 
 	// Update status after reconciliation.


### PR DESCRIPTION
## Current situation
If deployed via chart:
```
{"level":"error","ts":"2026-04-28T06:08:34.446Z","logger":"controller-runtime.cache.UnhandledError","msg":"Failed to watch","reflector":"pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290","type":"*v1beta1.Neo4jAuraInstance","error":"failed to list *v1beta1.Neo4jAuraInstance: neo4jaurainstances.cloudautoscale.infra.doodle.com is forbidden: User \"system:serviceaccount:devops:cloud-autoscale-controller\" cannot list resource \"neo4jaurainstances\" in API group \"cloudautoscale.infra.doodle.com\" at the cluster scope"}

```

## Proposal
<!--- Describe what this PR is intended to achieve -->